### PR TITLE
add mask for input

### DIFF
--- a/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
@@ -17,8 +17,11 @@ TEST(McmcDiagEMetric, sample_p) {
   q(0) = 5;
   q(1) = 1;
 
+  Eigen::VectorXd mask(q.size());
+  mask << 1, 0;
+
   stan::mcmc::mock_model model(q.size());
-  stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> metric(model);
+  stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> metric(model, mask);
   stan::mcmc::diag_e_point z(q.size());
 
   int n_samples = 1000;
@@ -52,6 +55,9 @@ TEST(McmcDiagEMetric, gradients) {
   z.q = q;
   z.p.setOnes();
 
+  Eigen::VectorXd mask(q.size());
+  mask << 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0;
+
   std::fstream data_stream(std::string("").c_str(), std::fstream::in);
   stan::io::dump data_var_context(data_stream);
   data_stream.close();
@@ -64,7 +70,7 @@ TEST(McmcDiagEMetric, gradients) {
   stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
 
   stan::mcmc::diag_e_metric<funnel_model_namespace::funnel_model, rng_t> metric(
-      model);
+      model, mask);
 
   double epsilon = 1e-6;
 
@@ -147,10 +153,12 @@ TEST(McmcDiagEMetric, streams) {
 
   stan::mcmc::mock_model model(q.size());
 
+  Eigen::VectorXd mask(q.size());
+  mask << 1, 0;
   // typedef to use within Google Test macros
   typedef stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> diag_e;
 
-  EXPECT_NO_THROW(diag_e metric(model));
+  EXPECT_NO_THROW(diag_e metric(model, mask));
 
   stan::test::reset_std_streams();
   EXPECT_EQ("", stan::test::cout_ss.str());


### PR DESCRIPTION
issue #3 

1. There are three tests, `TEST(McmcDiagEMetric, sample_p)`, `TEST(McmcDiagEMetric, gradients)`, `TEST(McmcDiagEMetric, streams)`. Updated code with mask passed the first and third test so it should be working, but for some reason I cannot understand the second test with funnel function model fails.
```
In file included from src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp:7:
In file included from ./test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp:3:
In file included from src/stan/model/model_header.hpp:13:
src/stan/model/model_base_crtp.hpp:206:50: error: 'transform_inits' following the 'template' keyword does not refer to a template
    return static_cast<const M*>(this)->template transform_inits(
                                                 ^
src/stan/model/model_base_crtp.hpp:86:11: note: in instantiation of member function
      'stan::model::model_base_crtp<funnel_model_namespace::funnel_model>::transform_inits' requested here
  virtual ~model_base_crtp() {}
          ^
./test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp:38:3: note: in instantiation of member function
      'stan::model::model_base_crtp<funnel_model_namespace::funnel_model>::~model_base_crtp' requested here
  ~funnel_model() { }
  ^
./test/test-models/good/mcmc/hmc/hamiltonians/funnel.hpp:344:17: note: declared as a non-template here
    inline void transform_inits(const stan::io::var_context& context,
                ^
1 error generated.
make: *** [test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.o] Error 1
make -j1 test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test failed
```

2. Fixed parameters might affect NUTS so the [following](https://github.com/stan-dev/stan/blob/540105b9b43303f2fe70cb8f438f5a2b96d0a442/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp#L28) used in [here](https://github.com/stan-dev/stan/blob/540105b9b43303f2fe70cb8f438f5a2b96d0a442/src/test/unit/mcmc/hmc/nuts/base_nuts_test.cpp#L71) might need some modification w.r.t the mask. Would this matter? @bbbales2 

`double dG_dt(diag_e_point& z, callbacks::logger& logger) {    return 2 * T(z) - z.q.dot(z.g);  }`
