### PR TITLE
More changes to make mask work with diagonal nuts

### DIFF
--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_metric.hpp
@@ -14,12 +14,13 @@ namespace mcmc {
 template <class Model, class BaseRNG>
 class diag_e_metric : public base_hamiltonian<Model, diag_e_point, BaseRNG> {
  public:
-  explicit diag_e_metric(const Model& model, const Eigen::VectorXd& mask_vec)
-      : base_hamiltonian<Model, diag_e_point, BaseRNG>(model), mask{mask_vec} {}
+  explicit diag_e_metric(const Model& model)
+  : base_hamiltonian<Model, diag_e_point, BaseRNG>(model) {}
 
   double T(diag_e_point& z) {
     return 0.5 * z.p.dot(z.inv_e_metric_.cwiseProduct(z.p));
   }
+
   double tau(diag_e_point& z) { return T(z); }
 
   double phi(diag_e_point& z) { return this->V(z); }
@@ -33,22 +34,19 @@ class diag_e_metric : public base_hamiltonian<Model, diag_e_point, BaseRNG> {
   }
 
   Eigen::VectorXd dtau_dp(diag_e_point& z) {
-    return mask.cwiseProduct(z.inv_e_metric_.cwiseProduct(z.p));
+    return z.mask_.cwiseProduct(z.inv_e_metric_.cwiseProduct(z.p));
   }
 
   Eigen::VectorXd dphi_dq(diag_e_point& z, callbacks::logger& logger) {
-    return mask.cwiseProduct(z.g);
+    return z.mask_.cwiseProduct(z.g);
   }
 
   void sample_p(diag_e_point& z, BaseRNG& rng) {
     boost::variate_generator<BaseRNG&, boost::normal_distribution<> >
         rand_diag_gaus(rng, boost::normal_distribution<>());
-
     for (int i = 0; i < z.p.size(); ++i)
-      z.p(i) = rand_diag_gaus() / sqrt(z.inv_e_metric_(i));
+      z.p(i) = z.mask_.coeffRef(i) * rand_diag_gaus() / sqrt(z.inv_e_metric_(i));
   }
- private:
-    const Eigen::VectorXd& mask;
 };
 
 }  // namespace mcmc

--- a/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
+++ b/src/stan/mcmc/hmc/hamiltonians/diag_e_point.hpp
@@ -16,6 +16,7 @@ class diag_e_point : public ps_point {
    * Vector of diagonal elements of inverse mass matrix.
    */
   Eigen::VectorXd inv_e_metric_;
+  Eigen::VectorXd mask_;
 
   /**
    * Construct a diag point in n-dimensional phase space
@@ -23,8 +24,9 @@ class diag_e_point : public ps_point {
    *
    * @param n number of dimensions
    */
-  explicit diag_e_point(int n) : ps_point(n), inv_e_metric_(n) {
+  explicit diag_e_point(int n) : ps_point(n), inv_e_metric_(n), mask_(n) {
     inv_e_metric_.setOnes();
+    mask_.setOnes();
   }
 
   /**
@@ -34,6 +36,15 @@ class diag_e_point : public ps_point {
    */
   void set_metric(const Eigen::VectorXd& inv_e_metric) {
     inv_e_metric_ = inv_e_metric;
+  }
+
+  /**
+   * Set the mask
+   * 
+   * @param mask the new mask
+   */
+  void set_mask(const Eigen::VectorXd& mask) {
+    mask_ = mask;
   }
 
   /**

--- a/src/stan/mcmc/hmc/nuts/base_nuts.hpp
+++ b/src/stan/mcmc/hmc/nuts/base_nuts.hpp
@@ -65,6 +65,10 @@ class base_nuts : public base_hmc<Model, Hamiltonian, Integrator, BaseRNG> {
     this->z_.set_metric(inv_e_metric);
   }
 
+  void set_mask(const Eigen::VectorXd& mask) {
+    this->z_.set_mask(mask);
+  }
+
   void set_max_depth(int d) {
     if (d > 0)
       max_depth_ = d;

--- a/src/stan/model/model_base_crtp.hpp
+++ b/src/stan/model/model_base_crtp.hpp
@@ -207,7 +207,7 @@ class model_base_crtp : public stan::model::model_base {
                                                         msgs);
   }
 
-  inline std::string get_unconstrained_sizedtypes() const {
+  inline std::string get_unconstrained_sizedtypes() const override {
     return static_cast<const M*>(this)->get_unconstrained_sizedtypes();
   }
 };

--- a/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
+++ b/src/stan/services/sample/hmc_nuts_diag_e_adapt.hpp
@@ -10,6 +10,7 @@
 #include <stan/services/error_codes.hpp>
 #include <stan/mcmc/hmc/nuts/adapt_diag_e_nuts.hpp>
 #include <stan/services/util/run_adaptive_sampler.hpp>
+#include <stan/services/util/create_param_mask.hpp>
 #include <stan/services/util/create_rng.hpp>
 #include <stan/services/util/initialize.hpp>
 #include <stan/services/util/inv_metric.hpp>
@@ -79,9 +80,12 @@ int hmc_nuts_diag_e_adapt(
     return error_codes::CONFIG;
   }
 
+  Eigen::VectorXd mask = util::create_param_mask(model.get_unconstrained_sizedtypes(), clamped_params);
+
   stan::mcmc::adapt_diag_e_nuts<Model, boost::ecuyer1988> sampler(model, rng);
 
   sampler.set_metric(inv_metric);
+  sampler.set_mask(mask);
   sampler.set_nominal_stepsize(stepsize);
   sampler.set_stepsize_jitter(stepsize_jitter);
   sampler.set_max_depth(max_depth);

--- a/src/stan/services/util/create_param_mask.hpp
+++ b/src/stan/services/util/create_param_mask.hpp
@@ -46,7 +46,7 @@ void build_mask_recursive(std::vector<double>& v, const T& rtype_obj, bool clamp
  * @param clamped var_context with clamped parameters
  * @return mask as Eigen::VectorXd with 1s for unclamped parameters and 0s for clamped parameters
  */
-Eigen::VectorXd create_param_mask(std::string& unconstrained_param_str, stan::io::var_context& clamped){
+Eigen::VectorXd create_param_mask(const std::string& unconstrained_param_str, const stan::io::var_context& clamped){
   rapidjson::Document d;
   d.Parse(unconstrained_param_str.c_str());
 

--- a/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
@@ -17,11 +17,8 @@ TEST(McmcDiagEMetric, sample_p) {
   q(0) = 5;
   q(1) = 1;
 
-  Eigen::VectorXd mask(q.size());
-  mask << 1, 0;
-
   stan::mcmc::mock_model model(q.size());
-  stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> metric(model, mask);
+  stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> metric(model);
   stan::mcmc::diag_e_point z(q.size());
 
   int n_samples = 1000;
@@ -46,6 +43,45 @@ TEST(McmcDiagEMetric, sample_p) {
   EXPECT_TRUE(std::fabs(var - 0.5 * q.size()) < 0.1 * q.size());
 }
 
+
+TEST(McmcDiagEMetric, mask) {
+  std::stringstream debug, info, warn, error, fatal;
+  stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
+  rng_t base_rng(0);
+
+  Eigen::VectorXd q(2);
+  q(0) = 5;
+  q(1) = 1;
+
+  Eigen::VectorXd mask(q.size());
+  mask << 1, 0;
+
+  stan::mcmc::mock_model model(q.size());
+  stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> metric(model);
+  stan::mcmc::diag_e_point z_no_mask(q.size());
+
+  stan::mcmc::diag_e_point z_mask(q.size());
+  z_mask.set_mask(mask);
+
+  EXPECT_FLOAT_EQ(z_no_mask.mask_(0), 1.0);
+  EXPECT_FLOAT_EQ(z_no_mask.mask_(1), 1.0);
+
+  EXPECT_FLOAT_EQ(z_mask.mask_(0), 1.0);
+  EXPECT_FLOAT_EQ(z_mask.mask_(1), 0.0);
+
+  Eigen::VectorXd dtau_dp_no_mask = metric.dtau_dp(z_no_mask);
+  Eigen::VectorXd dtau_dp_mask = metric.dtau_dp(z_mask);
+
+  Eigen::VectorXd dphi_dq_no_mask = metric.dphi_dq(z_no_mask, logger);
+  Eigen::VectorXd dphi_dq_mask = metric.dphi_dq(z_mask, logger);
+
+  EXPECT_EQ(dtau_dp_no_mask(0), dtau_dp_mask(0));
+  EXPECT_FLOAT_EQ(dtau_dp_mask(1), 0.0);
+
+  EXPECT_EQ(dphi_dq_no_mask(0), dphi_dq_mask(0));
+  EXPECT_FLOAT_EQ(dphi_dq_mask(1), 0.0);
+}
+
 TEST(McmcDiagEMetric, gradients) {
   rng_t base_rng(0);
 
@@ -54,9 +90,6 @@ TEST(McmcDiagEMetric, gradients) {
   stan::mcmc::diag_e_point z(q.size());
   z.q = q;
   z.p.setOnes();
-
-  Eigen::VectorXd mask(q.size());
-  mask << 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0;
 
   std::fstream data_stream(std::string("").c_str(), std::fstream::in);
   stan::io::dump data_var_context(data_stream);
@@ -69,8 +102,7 @@ TEST(McmcDiagEMetric, gradients) {
   std::stringstream debug, info, warn, error, fatal;
   stan::callbacks::stream_logger logger(debug, info, warn, error, fatal);
 
-  stan::mcmc::diag_e_metric<funnel_model_namespace::funnel_model, rng_t> metric(
-      model, mask);
+  stan::mcmc::diag_e_metric<funnel_model_namespace::funnel_model, rng_t> metric(model);
 
   double epsilon = 1e-6;
 
@@ -153,12 +185,10 @@ TEST(McmcDiagEMetric, streams) {
 
   stan::mcmc::mock_model model(q.size());
 
-  Eigen::VectorXd mask(q.size());
-  mask << 1, 0;
   // typedef to use within Google Test macros
   typedef stan::mcmc::diag_e_metric<stan::mcmc::mock_model, rng_t> diag_e;
 
-  EXPECT_NO_THROW(diag_e metric(model, mask));
+  EXPECT_NO_THROW(diag_e metric(model));
 
   stan::test::reset_std_streams();
   EXPECT_EQ("", stan::test::cout_ss.str());

--- a/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
+++ b/src/test/unit/mcmc/hmc/hamiltonians/diag_e_metric_test.cpp
@@ -80,6 +80,17 @@ TEST(McmcDiagEMetric, mask) {
 
   EXPECT_EQ(dphi_dq_no_mask(0), dphi_dq_mask(0));
   EXPECT_FLOAT_EQ(dphi_dq_mask(1), 0.0);
+
+  metric.sample_p(z_no_mask, base_rng);
+  metric.sample_p(z_mask, base_rng);
+  Eigen::VectorXd sample_p_no_mask = z_no_mask.p;
+  Eigen::VectorXd sample_p_mask = z_mask.p;
+
+  EXPECT_NE(sample_p_no_mask(0), 0.0);
+  EXPECT_NE(sample_p_no_mask(1), 0.0);
+
+  EXPECT_NE(sample_p_mask(0), 0.0);
+  EXPECT_FLOAT_EQ(sample_p_mask(1), 0.0);
 }
 
 TEST(McmcDiagEMetric, gradients) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Declare copyright holder and open-source license: see below

#### Summary

I think we need tests to make sure:
```
dtau_dp
dphi_dq
sample_p
```

are vaguely handling masks correctly. Maybe 1 test per function?

We should also test that base_nuts.hpp::set_mask is working if it's easy

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
